### PR TITLE
Fix invalid line in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,10 +3,7 @@ version=0.1
 author=Greg Bumgardner <gbumgard@gmail.com>
 maintainer=Greg Bumgardner <gbumgard@gmail.com>
 sentence=Arguino library for controlling Dynamixel servos.
-paragraph=This library provides an API for controlling Dynamixel servos via the DynamixelBus C++ class.
-Each instance of this class must be connected to a single hardware serial interface. DynamixelBus can query
-a serial interface to find all connected servos. The class provides R/W (as appropriate) for all control
-table entries in each servo.
+paragraph=This library provides an API for controlling Dynamixel servos via the DynamixelBus C++ class. Each instance of this class must be connected to a single hardware serial interface. DynamixelBus can query a serial interface to find all connected servos. The class provides R/W (as appropriate) for all control table entries in each servo.
 category=Device Control
 url=https://github.com/gbumgard/DynamixelBus
 architectures=avr


### PR DESCRIPTION
Each line in library.properties must either contain an '=', start with a #, or be whitespace. Installation of a library with an invalid line will cause compilation of any code (even if it doesn't #include the library) to fail:

Property line '...' in file ... is invalid

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format